### PR TITLE
Fix deleteRecordForDomain, which returns no body. (Alternative to PR #2)

### DIFF
--- a/lib/dnsmadeeasy/core.js
+++ b/lib/dnsmadeeasy/core.js
@@ -104,7 +104,7 @@ _.extend(Client.prototype, {
         if (err) {
           return reject(err);
         }
-        resolve(JSON.parse(body));
+        resolve((body && body.length > 0) ? JSON.parse(body) : body);
       });
     });
   },

--- a/lib/dnsmadeeasy/managedDns.spec.js
+++ b/lib/dnsmadeeasy/managedDns.spec.js
@@ -408,16 +408,12 @@ describe('ManagedDns', function() {
         reqheaders: headers
       })
         .post('/dns/managed/1/records')
-        .reply(200, {
-          status: 'ok'
-        });
+        .reply(200);
 
       var managedDns = ManagedDns.createManagedDNS(client);
 
       var response = yield managedDns.createRecordForDomain(1, {});
-      expect(response).to.be.eql({
-        status: 'ok'
-      });
+      expect(response).to.be.equal('');
     });
   });
 


### PR DESCRIPTION
This PR builds on PR #2 by updating test coverage. The old test coverage
mocked the wrong response from API, which hid that the related code was broken.

After I corrected the test coverage, it confirmed both that the bug that Victor found was real,
and that his patch corrected the issue.