### PR TITLE
Fixed SyntaxError on JSON.parse

### DIFF
--- a/lib/dnsmadeeasy/core.js
+++ b/lib/dnsmadeeasy/core.js
@@ -104,7 +104,13 @@ _.extend(Client.prototype, {
         if (err) {
           return reject(err);
         }
-        resolve(JSON.parse(body));
+        
+        try {
+          resolve(JSON.parse(body));
+        } catch (err) {
+          // Apparently the result is not a JSON. That's fine
+          resolve();
+        }
       });
     });
   },


### PR DESCRIPTION
Hey,

This a fix for #1 as it's a blocker right now. Could you merge it and release a new version? Otherwise, it's impossible to delete records and it's impossible to catch the error now.